### PR TITLE
Removed unused dependency on xmltodict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup_args = dict(
 
 install_requires = [
     'requests',
-    'xmltodict'
 ]
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR removes the dependency on `xmltodict`, since support for XML was dropped from this library.